### PR TITLE
Bidirectionality fixes and probe for the Kernel Data Relay

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@lumino/algorithm": "^1.3.3",
     "@lumino/messaging": "^1.4.3",
     "@lumino/widgets": "^1.14.0",
-    "@wwtelescope/research-app-messages": "^0.7.0"
+    "@wwtelescope/research-app-messages": "^0.7.1"
   },
   "description": "AAS WorldWide Telescope in JupyterLab",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@lumino/algorithm": "^1.3.3",
     "@lumino/messaging": "^1.4.3",
     "@lumino/widgets": "^1.14.0",
-    "@wwtelescope/research-app-messages": "^0.4.0"
+    "@wwtelescope/research-app-messages": "^0.7.0"
   },
   "description": "AAS WorldWide Telescope in JupyterLab",
   "devDependencies": {

--- a/src/comms.ts
+++ b/src/comms.ts
@@ -1,4 +1,4 @@
-// Copyright 2020 the .NET Foundation
+// Copyright 2020-2021 the .NET Foundation
 // Licensed under the MIT License.
 
 /** It took me SO LONG to get something to work reliably here. I wanted to
@@ -20,9 +20,28 @@ import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 
 import { Kernel, KernelMessage, Session } from '@jupyterlab/services';
 
+import {
+  isPingPongMessage,
+  PingPongMessage
+} from '@wwtelescope/research-app-messages';
+
+class Connection {
+  comm: Kernel.IComm;
+  kernelThinksAppIsAlive: boolean;
+
+  constructor(comm: Kernel.IComm) {
+    this.comm = comm;
+    this.kernelThinksAppIsAlive = false;
+  }
+}
+
+const APP_PING_INTERVAL_MS = 1000;
+const APP_PONG_DEADLINE_MS = 2500;
+
 export class WWTLabCommManager {
   private readonly targetName: string;
-  private activeComms: Map<string, Kernel.IComm> = new Map();
+  private activeComms: Map<string, Connection> = new Map();
+  private lastPongTimestamp = 0;
 
   constructor(targetName: string, notebooks: INotebookTracker) {
     this.targetName = targetName;
@@ -30,6 +49,8 @@ export class WWTLabCommManager {
       this.monitorPanel(np)
     );
     notebooks.forEach(this.monitorPanel);
+
+    setInterval(this.pingAndCheck, APP_PING_INTERVAL_MS);
   }
 
   public dataRelayConfirmedAvailable = false;
@@ -63,7 +84,7 @@ export class WWTLabCommManager {
     msg: KernelMessage.ICommOpenMsg
   ): void => {
     if (msg.content.target_name === this.targetName) {
-      this.activeComms.set(comm.commId, comm);
+      this.activeComms.set(comm.commId, new Connection(comm));
       comm.onMsg = this.onCommMessage;
       comm.onClose = (msg: KernelMessage.ICommCloseMsg): void => {
         this.activeComms.delete(comm.commId);
@@ -89,16 +110,36 @@ export class WWTLabCommManager {
   // intentionally modifiable -- this is how one signs up for notifications
   public onAnyMessage = (d: JSONObject): void => {}; // eslint-disable-line @typescript-eslint/no-empty-function
 
+  // This function is called by the viewer when it has received a message from
+  // the app. We should distribute it to all connected kernels. The messages
+  // themselves include unique IDs that kernels should use to determine which
+  // ones they should pay attention to.
   public broadcastMessage(d: JSONObject): void {
+    // Special handling: "pong" replies to our ping messages
+
+    if (isPingPongMessage(d) && d.sessionId === this.targetName) {
+      const ts = Number(d.threadId);
+
+      if (ts <= 0 || isNaN(ts)) {
+        console.warn('wwt-jupyterlab: non-numeric threadId value', d.threadId);
+      } else {
+        this.lastPongTimestamp = ts;
+      }
+
+      return;
+    }
+
+    // OK, this is a generic message.
+
     const toRemove: string[] = [];
 
-    this.activeComms.forEach((comm: Kernel.IComm) => {
+    this.activeComms.forEach((conn: Connection) => {
       try {
-        comm.send(d);
+        conn.comm.send(d);
       } catch {
         // We can get errors when kernels go away. AFAICT the most
         // robust approach is to deal with this here.
-        toRemove.push(comm.commId);
+        toRemove.push(conn.comm.commId);
       }
     });
 
@@ -106,4 +147,47 @@ export class WWTLabCommManager {
       this.activeComms.delete(id);
     });
   }
+
+  // Periodically (1) issue a ping message and (2) see whether we've recently
+  // received a "pong". This is only correct way to keep tabs on whether the app
+  // viewer is handling messasges, since even if the iframe exists, it may not
+  // have booted up, etc.
+  private readonly pingAndCheck = (): void => {
+    // Send the ping
+
+    const ping: PingPongMessage = {
+      type: 'wwt_ping_pong',
+      sessionId: this.targetName,
+      threadId: '' + Date.now()
+    };
+
+    this.onAnyMessage(ping as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    // Have we had a recent pong?
+
+    const appAlive = (Date.now() - this.lastPongTimestamp) < APP_PONG_DEADLINE_MS; // eslint-disable-line prettier/prettier
+
+    // Notify clients of any state changes
+
+    const toRemove: string[] = [];
+    const msg = {
+      type: 'wwt_jupyter_viewer_status',
+      alive: appAlive
+    };
+
+    this.activeComms.forEach((conn: Connection) => {
+      if (conn.kernelThinksAppIsAlive !== appAlive) {
+        try {
+          conn.comm.send(msg);
+          conn.kernelThinksAppIsAlive = appAlive;
+        } catch {
+          toRemove.push(conn.comm.commId);
+        }
+      }
+    });
+
+    toRemove.forEach((id: string) => {
+      this.activeComms.delete(id);
+    });
+  };
 }

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -5,10 +5,7 @@ import { JSONObject } from '@lumino/coreutils';
 
 import { Widget } from '@lumino/widgets';
 
-import {
-  classicPywwt,
-  isViewStateMessage
-} from '@wwtelescope/research-app-messages';
+import { classicPywwt } from '@wwtelescope/research-app-messages';
 
 import { WWTLabCommManager } from './comms';
 
@@ -55,15 +52,7 @@ export class WWTLabViewer extends Widget {
 
   private onIframeMessage(msg: any): void {
     // eslint-disable-line @typescript-eslint/no-explicit-any
-    if (isViewStateMessage(msg)) {
-      // Relay to the client kernel so it knows what's going on.
-      this.comms.broadcastMessage(msg as any); // eslint-disable-line @typescript-eslint/no-explicit-any
-    } else {
-      console.warn(
-        'WWT JupyterLab viewer got unexpected message from app, as follows:',
-        msg
-      );
-    }
+    this.comms.broadcastMessage(msg as any); // eslint-disable-line @typescript-eslint/no-explicit-any
   }
 
   private readonly processCommMessage = (d: JSONObject): void => {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -34,6 +34,8 @@ export class WWTLabViewer extends Widget {
       false
     );
 
+    this.comms = comms;
+
     this.iframe = document.createElement('iframe');
     // Pass our origin so that the iframe can validate the provenance of the
     // messages that are posted to it. This isn't acceptable for real XSS
@@ -44,10 +46,15 @@ export class WWTLabViewer extends Widget {
       IFRAME_URL + '?origin=' + encodeURIComponent(location.origin);
     this.iframe.style.setProperty('height', '100%', '');
     this.iframe.style.setProperty('width', '100%', '');
-    this.node.appendChild(this.iframe);
 
-    this.comms = comms;
-    comms.onAnyMessage = this.processCommMessage;
+    // Don't start trying to process messages until the iframe is loaded.
+    // Otherwise we can get an error where our postMessage goes to the wrong
+    // place.
+    this.iframe.addEventListener('load', () => {
+      comms.onAnyMessage = this.processCommMessage;
+    });
+
+    this.node.appendChild(this.iframe);
   }
 
   private onIframeMessage(msg: any): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,10 +38,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@blueprintjs/core@^3.36.0", "@blueprintjs/core@^3.46.0":
-  version "3.46.0"
-  resolved "https://registry.yarnpkg.com/@blueprintjs/core/-/core-3.46.0.tgz#fde92406ed97d48c949d5fe5578e7880efdf7577"
-  integrity sha512-kcYrisJMz7jPIuTc9AwFAbHMmmP/BxM2CC3e8vLaLk5h+xtXVzRipx19GA6ysSdguYXOnCPETwM6421QLehCCw==
+"@blueprintjs/core@^3.36.0", "@blueprintjs/core@^3.47.0":
+  version "3.47.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/core/-/core-3.47.0.tgz#bf33155d224b742ba51c6e1cf5be4523290337a7"
+  integrity sha512-u+bfmCyPXwKZMnwY4+e/iWjO2vDUvr8hA8ydmV0afyvcEe7Sh85UPEorIgQ/CBuRIbVMNm8FpLsFzDxgkfrCNA==
   dependencies:
     "@blueprintjs/icons" "^3.27.0"
     "@types/dom4" "^2.0.1"
@@ -64,11 +64,11 @@
     tslib "~1.13.0"
 
 "@blueprintjs/select@^3.15.0":
-  version "3.16.5"
-  resolved "https://registry.yarnpkg.com/@blueprintjs/select/-/select-3.16.5.tgz#31b15a606dafd15643aa539d93d74795ec2aabe4"
-  integrity sha512-+DJF7Fy11NjV1mUBHtEyx4fQTZDBki8NxxTZLsQWD6lGnUkZQDWToWmkr3oDC1+4MFG++Hf0nKvdp48FqY44IA==
+  version "3.16.6"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/select/-/select-3.16.6.tgz#ae41a73bc7c23b07a20b0c50c71273c9d5d0d83d"
+  integrity sha512-lg2duuzlRw18+pbET6vlRY/TVSuuSI6wI4DObUiBAfU7G3fMa6d10Sp+0Yn00XaMPQ5y3MGn1gz0EbIJ3/A5OA==
   dependencies:
-    "@blueprintjs/core" "^3.46.0"
+    "@blueprintjs/core" "^3.47.0"
     classnames "^2.2"
     tslib "~1.13.0"
 
@@ -617,9 +617,9 @@
     "@lumino/virtualdom" "^1.11.0"
 
 "@types/dom4@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.1.tgz#506d5781b9bcab81bd9a878b198aec7dee2a6033"
-  integrity sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.2.tgz#6495303f049689ce936ed328a3e5ede9c51408ee"
+  integrity sha512-Rt4IC1T7xkCWa0OG1oSsPa0iqnxlDeQqKXZAHrQGLb7wFGncWm85MaxKUjAGejOrUynOgWlFi4c6S6IyJwoK4g==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -693,15 +693,15 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@wwtelescope/research-app-messages@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@wwtelescope/research-app-messages/-/research-app-messages-0.4.0.tgz#ecb4480d5e38adafabe168007ad6f286663d28a2"
-  integrity sha512-egdfWZMCWDz619NIatqoYXVoBTLihgkXV7/xc1M4slbl7qpFu7dQKNA3B3oTUSX54GhpijGRNUOZZJ/9p1C3ZA==
+"@wwtelescope/research-app-messages@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@wwtelescope/research-app-messages/-/research-app-messages-0.7.0.tgz#aee6cf468cd72c9dce0c93276fcbd31ceaf343a1"
+  integrity sha512-oJz1Bci8JRjcObRaetZJk7/oFQONaN67zqIZwUqf+gUaRTV2N4rg03ZbW/fLvuIu4jitIsITLlB2SGzxImwD1Q==
 
 acorn-jsx@^5.2.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
-  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn@^7.1.1:
   version "7.4.1"
@@ -2517,9 +2517,9 @@ write@1.0.3:
     mkdirp "^0.5.1"
 
 ws@^7.2.0:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.2.tgz#09cc8fea3bec1bc5ed44ef51b42f945be36900f6"
-  integrity sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
+  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
 
 xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -693,10 +693,10 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@wwtelescope/research-app-messages@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@wwtelescope/research-app-messages/-/research-app-messages-0.7.0.tgz#aee6cf468cd72c9dce0c93276fcbd31ceaf343a1"
-  integrity sha512-oJz1Bci8JRjcObRaetZJk7/oFQONaN67zqIZwUqf+gUaRTV2N4rg03ZbW/fLvuIu4jitIsITLlB2SGzxImwD1Q==
+"@wwtelescope/research-app-messages@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@wwtelescope/research-app-messages/-/research-app-messages-0.7.1.tgz#7b2e5cb915bc151970423e3d2383e3aeddf8e8a0"
+  integrity sha512-BG7joZMgfmJDYoxcjT+Qkqdrjh0ZEEbIRyEYOHd9GiCq1ji2BUx3V9G6UmCk54zwITmhgVvcVZNMKIRGgttLaQ==
 
 acorn-jsx@^5.2.0:
   version "5.3.2"


### PR DESCRIPTION
Some improvements to support some new, more sophisticated use cases:

- Probe the presence of our Kernel Data Relay extension for Jupyter, which is going to be necessary to allow kernels to serve up tiled imagery
- Keep clients informed about whether the app is alive or not
- Relay all messages from the app. We shouldn't be in the business of having to "know about" different kinds of messages.
- Avoid a minor race condition with message processing as the app starts up