### PR TITLE
Add _pywwtExpedite tags for pywwt's Jupyter async skullduggery

### DIFF
--- a/src/comms.ts
+++ b/src/comms.ts
@@ -93,6 +93,7 @@ export class WWTLabCommManager {
       // Send some startup information to the kernel.
       try {
         comm.send({
+          content: { _pywwtExpedite: true },
           type: 'wwt_jupyter_startup_info',
           dataRelayConfirmedAvailable: this.dataRelayConfirmedAvailable
         });
@@ -128,6 +129,9 @@ export class WWTLabCommManager {
 
       return;
     }
+
+    d = Object.assign({ content: {} }, d);
+    (d['content'] as any)['_pywwtExpedite'] = true; // eslint-disable-line @typescript-eslint/no-explicit-any
 
     // OK, this is a generic message.
 
@@ -171,6 +175,7 @@ export class WWTLabCommManager {
 
     const toRemove: string[] = [];
     const msg = {
+      content: { _pywwtExpedite: true },
       type: 'wwt_jupyter_viewer_status',
       alive: appAlive
     };

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -11,7 +11,8 @@ import { WWTLabCommManager } from './comms';
 
 // TODO: make runtime configurable
 // XXX: hardcoding "latest"
-const IFRAME_URL = 'https://web.wwtassets.org/research/latest/';
+//const IFRAME_URL = 'https://web.wwtassets.org/research/latest/';
+const IFRAME_URL = 'http://localhost:8080/';
 
 export class WWTLabViewer extends Widget {
   private readonly comms: WWTLabCommManager;


### PR DESCRIPTION
In order for user code to be able to interact with WWT with proper async characteristics, we need to hack the Python kernel to expedite processing of WWT messages, for reasons laid out in detail in the corresponding pywwt code. Here we add the special tag that requests expedited processing. If the kernel isn't hacked, then nothing unusual happens.