### PR TITLE
Enable drag operations over the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@lumino/algorithm": "^1.3.3",
     "@lumino/messaging": "^1.4.3",
     "@lumino/widgets": "^1.14.0",
-    "@wwtelescope/research-app-messages": "^0.11.2"
+    "@wwtelescope/research-app-messages": "^0.15"
   },
   "description": "AAS WorldWide Telescope in JupyterLab",
   "devDependencies": {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -62,8 +62,25 @@ export class WWTLabViewer extends Widget {
   }
 
   private onIframeMessage(msg: any): void {
-    // eslint-disable-line @typescript-eslint/no-explicit-any
-    this.comms.broadcastMessage(msg as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    // Relaying pointer move and up events to parent elements to allow drag
+    // operations over the iframe. For example, when moving windows inside
+    // jupyter lab.
+    if (msg.type == 'wwt_pointer_move' || msg.type == 'wwt_pointer_up'){
+        var boundingClientRect = this.iframe.getBoundingClientRect();
+        // Jupyter lab seems to not listen to pointer events, so we use mouse
+        // events instead.
+        var mouseEvent = new MouseEvent(msg.type == 'wwt_pointer_move' ? 'mousemove' : 'mouseup', {
+          bubbles: true,
+          cancelable: false,
+          clientX: msg.clientX + boundingClientRect.left,
+          clientY: msg.clientY + boundingClientRect.top
+        });
+
+        this.iframe.dispatchEvent(mouseEvent);
+    } else {
+      // eslint-disable-line @typescript-eslint/no-explicit-any
+      this.comms.broadcastMessage(msg as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    }
   }
 
   private readonly processCommMessage = (d: JSONObject): void => {

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -65,18 +65,21 @@ export class WWTLabViewer extends Widget {
     // Relaying pointer move and up events to parent elements to allow drag
     // operations over the iframe. For example, when moving windows inside
     // jupyter lab.
-    if (msg.type == 'wwt_pointer_move' || msg.type == 'wwt_pointer_up'){
-        var boundingClientRect = this.iframe.getBoundingClientRect();
-        // Jupyter lab seems to not listen to pointer events, so we use mouse
-        // events instead.
-        var mouseEvent = new MouseEvent(msg.type == 'wwt_pointer_move' ? 'mousemove' : 'mouseup', {
+    if (msg.type === 'wwt_pointer_move' || msg.type === 'wwt_pointer_up') {
+      const boundingClientRect = this.iframe.getBoundingClientRect();
+      // Jupyter lab seems to not listen to pointer events, so we use mouse
+      // events instead.
+      const mouseEvent = new MouseEvent(
+        msg.type === 'wwt_pointer_move' ? 'mousemove' : 'mouseup',
+        {
           bubbles: true,
           cancelable: false,
           clientX: msg.clientX + boundingClientRect.left,
-          clientY: msg.clientY + boundingClientRect.top
-        });
+          clientY: msg.clientY + boundingClientRect.top,
+        }
+      );
 
-        this.iframe.dispatchEvent(mouseEvent);
+      this.iframe.dispatchEvent(mouseEvent);
     } else {
       // eslint-disable-line @typescript-eslint/no-explicit-any
       this.comms.broadcastMessage(msg as any); // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,10 +1149,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.0.tgz#2c275aa05c895eccebbfc34cfb223c6e8bd591a2"
   integrity sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==
 
-"@wwtelescope/research-app-messages@^0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@wwtelescope/research-app-messages/-/research-app-messages-0.11.2.tgz#7d5da854d5a1a5c61f6509bc2911d9ff2e1bf8b7"
-  integrity sha512-UitgJ1OMURyHbzjtac1bm60kMqr5Vg2c1XS6lCP4MFf08nziZDQgR0Qn4KGZJ6sjr7V8CDvKTUorlosrNACWug==
+"@wwtelescope/research-app-messages@^0.15":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@wwtelescope/research-app-messages/-/research-app-messages-0.15.0.tgz#a207517fc9ba203b651b242b73bf3298c103a619"
+  integrity sha512-sDK409YvWzfjwf9/Ve+HFyDsxgHFcDGOX5sc7WqXuF8WR8np4a5c1a9GXHukuMs31+41hRap7o9cfYA4PF/Lxg==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Added an iframe relay for mousemove and mouseup events to enable drag operations over the app. For more details, see: https://github.com/WorldWideTelescope/wwt-webgl-engine/pull/205