### PR TITLE
ci/azure-deployment.yml: fix NPM publishing (hopefully)

### DIFF
--- a/ci/azure-deployment.yml
+++ b/ci/azure-deployment.yml
@@ -56,7 +56,7 @@ jobs:
       env:
         GITHUB_TOKEN: $(GITHUB_TOKEN)
 
-  - job: npm_publish
+  - job: jlpm_publish
     pool:
       vmImage: ubuntu-latest
     variables:
@@ -78,7 +78,14 @@ jobs:
         set -euo pipefail
         source activate-conda.sh
         set -x
-        cranko npm foreach-released jlpm publish
+        jlpm build
+      displayName: jlpm build
+
+    - bash: |
+        set -euo pipefail
+        source activate-conda.sh
+        set -x
+        cranko npm foreach-released jlpm npm publish
       displayName: Publish to NPM
 
     - bash: shred ~/.npmrc

--- a/yarn.lock
+++ b/yarn.lock
@@ -4188,11 +4188,11 @@ __metadata:
 
 "typescript@patch:typescript@~5.0.2#~builtin<compat/typescript>":
   version: 5.0.4
-  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=85af82"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
+  checksum: bb309d320c59a26565fb3793dba550576ab861018ff3fd1b7fccabbe46ae4a35546bc45f342c0a0b6f265c801ccdf64ffd68f548f117ceb7f0eac4b805cd52a9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The 2.0.0 release had a hiccup in the automated NPM publishing.